### PR TITLE
One time usage + Protect

### DIFF
--- a/00100 General/00102 SkillChoice.rb
+++ b/00100 General/00102 SkillChoice.rb
@@ -32,7 +32,7 @@ module BattleUI
 
       prepend SpecialButtonZMovePlugin
 
-      alias_method :default_data, :data=
+      alias default_data data=
       # Set the data of the button
       # @param pokemon [PFM::PokemonBattler]
       def data=(pokemon)

--- a/00200 ZMoves/001 Protect.rb
+++ b/00200 ZMoves/001 Protect.rb
@@ -1,0 +1,40 @@
+module Battle
+  module Effects
+    # Implement the Protect effect
+    class Protect < PokemonTiedEffectBase
+      # Function called when we try to check if the target evades the move
+      # @param user [PFM::PokemonBattler]
+      # @param target [PFM::PokemonBattler] expected target
+      # @param move [Battle::Move]
+      # @return [Boolean] if the target is evading the move
+      def on_move_prevention_target(user, target, move)
+        return false if goes_through_protect?(user, target, move)
+        return false if z_move?(move) # Manque le message je crois
+
+        play_protect_effect(user, target, move)
+        return true
+      end
+
+      # Give the move mod3 mutiplier (after everything)
+      # @param user [PFM::PokemonBattler] user of the move
+      # @param target [PFM::PokemonBattler] target of the move
+      # @param move [Battle::Move] move
+      # @return [Float, Integer] multiplier
+      def mod3_multiplier(_user, target, move)
+        return 1 if target != @pokemon
+        return 1 unless z_move?(move)
+
+        return 0.25
+      end
+
+      # Check if the move is a Z Move or Dynamax Move
+      # @param move [Battle::Move]
+      # @return [Boolean]
+      def z_move?(move)
+        return true if move.instance_of?(Battle::Move::ZMove)
+
+        return false
+      end
+    end
+  end
+end

--- a/00200 ZMoves/00203 Logic.rb
+++ b/00200 ZMoves/00203 Logic.rb
@@ -10,7 +10,14 @@ module Battle
       def initialize(scene)
         # ZMove helper
         @z_move = ZMoves.new(scene)
+        @used_z_tool_bags = []
         super(scene)
+      end
+
+      # Mark a pokemon's team as Z-Move consumed
+      # @param pokemon [PFM::PokemonBattler]
+      def mark_as_z_move_used(pokemon)
+        @used_z_moves_tool_bags << pokemon.bag
       end
     end
 

--- a/00200 ZMoves/00204 ZMoves.rb
+++ b/00200 ZMoves/00204 ZMoves.rb
@@ -37,12 +37,12 @@ module Battle
           { specie: :lunala, forms: [0], base_move: :moongeist_beam, zmove: :menacing_moonraze_maelstrom, be_method: :s_basic },
           { specie: :necrozma, forms: [2], base_move: :moongeist_beam, zmove: :menacing_moonraze_maelstrom, be_method: :s_basic }
         ],
-        lycanium_z: [{ specie: :lycanroc, forms: [0, 1, 2], base_move: :stone_edge, zmove: :splintered_stormshards, be_method: :s_basic }],
+        lycanium_z: [{ specie: :lycanroc, forms: [0, 1, 2], base_move: :stone_edge, zmove: :splintered_stormshards, be_method: :s_ice_spinner }],
         marshadium_z: [{ specie: :marshadow, forms: [0], base_move: :spectral_thief, zmove: :soul_stealing_7_star_strike, be_method: :s_basic }],
         mewnium_z: [{ specie: :mew, forms: [0], base_move: :psychic, zmove: :genesis_supernova, be_method: :s_basic }],
         mimikium_z: [{ specie: :mimikyu, forms: [0], base_move: :play_rough, zmove: :let_s_snuggle_forever, be_method: :s_basic }],
         pikanium_z: [{ specie: :pikachu, forms: [0], base_move: :volt_tackle, zmove: :catastropika, be_method: :s_basic }],
-        pikashunium_z: [{ specie: :pikachu, forms: [7], base_move: :thunderbolt, zmove: :s10_000_000_volt_thunderbolt, be_method: :s_basic }],
+        pikashunium_z: [{ specie: :pikachu, forms: [8..14], base_move: :thunderbolt, zmove: :s10_000_000_volt_thunderbolt, be_method: :s_basic }],
         primarium_z: [{ specie: :primarina, forms: [0], base_move: :sparkling_aria, zmove: :oceanic_operetta, be_method: :s_basic }],
         snorlium_z: [{ specie: :snorlax, forms: [0], base_move: :giga_impact, zmove: :pulverizing_pancake, be_method: :s_basic }],
         solganium_z: [
@@ -55,7 +55,7 @@ module Battle
           { specie: :tapu_bulu, forms: [0], base_move: :nature_s_madness, zmove: :guardian_of_alola, be_method: :s_basic },
           { specie: :tapu_fini, forms: [0], base_move: :nature_s_madness, zmove: :guardian_of_alola, be_method: :s_basic }
         ],
-        ultranecrozium_z: [{ specie: :raichu, forms: [0], base_move: :photon_geyser, zmove: :light_that_burns_the_sky, be_method: :s_basic }]
+        ultranecrozium_z: [{ specie: :raichu, forms: [0], base_move: :photon_geyser, zmove: :light_that_burns_the_sky, be_method: :s_photon_geyser }]
       }
 
       # Create the Z-Moves checker

--- a/00200 ZMoves/00210 ZMove.rb
+++ b/00200 ZMoves/00210 ZMove.rb
@@ -89,54 +89,6 @@ module Battle
         power
       end
 
-      # Modified method calculating the damages done by the actual move by adding Z-move power calculation if target is protected
-      # @param user [PFM::PokemonBattler] user of the move
-      # @param target [PFM::PokemonBattler] target of the move
-      # @return [Integer]
-      def damages(user, target)
-        # rubocop:disable Layout/ExtraSpacing
-        # rubocop:disable Style/Semicolon
-        # rubocop:disable Style/SpaceBeforeSemicolon
-        log_data("# damages(#{user}, #{target}) for #{db_symbol}")
-        # Reset the effectiveness
-        @effectiveness = 1
-        @critical = logic.calc_critical_hit(user, target, critical_rate)                   ; log_data("@critical = #{@critical} # critical_rate = #{critical_rate}")
-        damage = user.level * 2 / 5 + 2                                                    ; log_data("damage = #{damage} # #{user.level} * 2 / 5 + 2")
-        damage = (damage * calc_base_power(user, target)).floor                            ; log_data("damage = #{damage} # after calc_base_power")
-        damage = (damage * calc_sp_atk(user, target)).floor / 50                           ; log_data("damage = #{damage} # after calc_sp_atk / 50")
-        damage = (damage / calc_sp_def(user, target)).floor                                ; log_data("damage = #{damage} # after calc_sp_def")
-        damage = (damage * calc_mod1(user, target)).floor + 2                              ; log_data("damage = #{damage} # after calc_mod1 + 2")
-        damage = (damage * calc_ch(user, target)).floor                                    ; log_data("damage = #{damage} # after calc_ch")
-        damage = (damage * calc_mod2(user, target)).floor                                  ; log_data("damage = #{damage} # after calc_mod2")
-        damage *= logic.move_damage_rng.rand(calc_r_range)
-        damage /= 100                                                                      ; log_data("damage = #{damage} # after rng")
-        types = definitive_types(user, target)
-        damage = (damage * calc_stab(user, types)).floor                                   ; log_data("damage = #{damage} # after stab")
-        damage = (damage * calc_type_n_multiplier(target, :type1, types)).floor            ; log_data("damage = #{damage} # after type1")
-        damage = (damage * calc_type_n_multiplier(target, :type2, types)).floor            ; log_data("damage = #{damage} # after type2")
-        damage = (damage * calc_type_n_multiplier(target, :type3, types)).floor            ; log_data("damage = #{damage} # after type3")
-        damage = (damage * calc_mod3(user, target)).floor                                  ; log_data("damage = #{damage} # after mod3")
-        damage = (damage * calc_z_move(target)).floor                                      ; log_data("damage = #{damage} # after z_move")
-        target_hp = target.effects.get(:substitute).hp if target.effects.has?(:substitute) && !user.has_ability?(:infiltrator) && !authentic?
-        target_hp ||= target.hp
-        damage = damage.clamp(1, target_hp)                                                ; log_data("damage = #{damage} # after clamp")
-
-        return damage
-        # rubocop:enable Layout/ExtraSpacing
-        # rubocop:enable Style/Semicolon
-        # rubocop:enable Style/SpaceBeforeSemicolon
-      end
-
-      # List of moves decreasing the Z-Moves damage to 25%
-      DECREASING_DAMAGE_MOVES = %i[protect detect spiky_shield baneful_bunker burning_bulwark king_s_shield mat_block obstruct silk_trap]
-
-      def calc_z_move(target)
-        last_move = target.successful_move_history.last
-        modifier = last_move.current_turn? && DECREASING_DAMAGE_MOVES.include?(last_move.move.db_symbol) ? 0.25 : 1
-
-        return modifier
-      end
-
       # Internal procedure of the move
       # @param user [PFM::PokemonBattler]
       # @param targets [Array<PFM::PokemonBattler>] expected targets

--- a/004 Action - ZMove.rb
+++ b/004 Action - ZMove.rb
@@ -1,0 +1,40 @@
+module Battle
+  module Actions
+    # Class describing the Z Move action
+    class ZMove < Base
+      # Get the user of this action
+      # @return [PFM::PokemonBattler]
+      attr_reader :user
+
+      # Create a new mega evolution action
+      # @param scene [Battle::Scene]
+      # @param user [PFM::PokemonBattler]
+      def initialize(scene, user)
+        super(scene)
+        @user = user
+      end
+
+      # Execute the action
+      def execute
+        @scene.logic.z_move.mark_as_used_z_move(@user)
+      end
+
+      private
+
+      # Get the pre mega evolve message
+      # @return [String]
+      def pre_mega_evolution_message
+        mega_evolution_with_mega_stone = @user.data.evolutions.find { |evolution| evolution.condition_data(:gemme) == @user.battle_item_db_symbol }
+        return parse_text_with_pokemon(19, 1247, @user, PFM::Text::TRNAME[1] => @user.trainer_name) unless mega_evolution_with_mega_stone
+
+        return parse_text_with_pokemon(
+          19, 1165, @user,
+          PFM::Text::PKNICK[0] => @user.given_name,
+          PFM::Text::ITEM2[2] => @user.item_name,
+          PFM::Text::TRNAME[1] => @user.trainer_name,
+          PFM::Text::ITEM2[3] => @scene.logic.mega_evolve.mega_tool_name(@user)
+        )
+      end
+    end
+  end
+end

--- a/101 Scene Choice.rb
+++ b/101 Scene Choice.rb
@@ -1,0 +1,27 @@
+module Battle
+  class Scene
+    # Method that asks the target of the choosen move
+    def target_choice
+      launcher, skill, target_bank, target_position, mega, zmove = @visual.show_target_choice
+      effect = launcher&.effects&.get(&:force_next_move?)
+      if launcher && skill
+        action_class = effect ? effect.action_class : Actions::Attack
+        next_action = action_class.new(self, skill, launcher, target_bank, target_position)
+        if mega
+          @player_actions << [next_action, Actions::Mega.new(self, launcher)]
+        elsif zmove
+          @player_actions << [next_action, Actions::ZMove.new(self, launcher)]
+        else
+          @player_actions << next_action
+        end
+        log_debug("Action : #{@player_actions.last}") if debug? # To prevent useless overhead outside debug
+        @next_update = can_player_make_another_action_choice? ? :player_action_choice : :trigger_all_AI
+      else
+        # If the player canceled we return to the player action
+        @next_update = effect ? :player_action_choice : :skill_choice
+      end
+    ensure
+      @skip_frame = true
+    end
+  end
+end

--- a/203 Show_skill_or_target_choice.rb
+++ b/203 Show_skill_or_target_choice.rb
@@ -1,0 +1,28 @@
+module Battle
+  class Visual
+    # Make the result of show_target_choice method
+    # @param result [Array, :auto, :cancel]
+    def stc_result(result = :auto)
+      return @skill_choice_ui.pokemon if result == :cancel && @skill_choice_ui.pokemon.effects.get(&:force_next_move?)
+      return nil if result == :cancel
+
+      arr = [@skill_choice_ui.pokemon, @skill_choice_ui.result]
+      if result.is_a?(Array)
+        arr.concat(result)
+      elsif result == :auto
+        targets = @skill_choice_ui.result.battler_targets(@skill_choice_ui.pokemon, @scene.logic)
+        if targets.empty?
+          arr.concat([1, 0])
+        else
+          arr << targets.first.bank
+          arr << targets.first.position
+        end
+      else
+        return nil
+      end
+      arr << @skill_choice_ui.mega_enabled
+      arr << @skill_choice_ui.zmove_enabled
+      return arr
+    end
+  end
+end


### PR DESCRIPTION
- Few Rubocop fixes.
- Added some Signature Z Moves' specific be_method.
- Removed Protect's calculation in `damages()`. Moved it by monkey-patching Protect's effect.
- Added ZMove action. That way, the z move disable from usage is properly implemented.